### PR TITLE
Fix: Cache Discogs-only metadata to prevent repeated API calls

### DIFF
--- a/scripts/clear_cache_for_upcs.py
+++ b/scripts/clear_cache_for_upcs.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+Script to clear cache entries for specific UPCs that may have stale or incomplete metadata.
+This is useful when reprocessing UPCs that previously failed due to incomplete metadata.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+import argparse
+
+# Add parent directory to path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.config import settings, is_development
+from src.utils.logger import get_logger, setup_logging
+from google.cloud import storage, firestore
+
+setup_logging("INFO")
+logger = get_logger(__name__)
+
+
+class CacheCleaner:
+    """Utility to clean cache entries for specific UPCs."""
+    
+    def __init__(self):
+        """Initialize cache cleaner."""
+        self.is_dev = is_development()
+        
+        if self.is_dev:
+            # Local cache directory
+            self.cache_dir = Path(__file__).parent.parent / ".cache"
+            logger.info(f"Using local cache directory: {self.cache_dir}")
+        else:
+            # Firestore for production
+            self.db = firestore.Client(project=settings.gcp_project_id)
+            self.collection = settings.firestore_collection_mbid
+            logger.info(f"Using Firestore collection: {self.collection}")
+    
+    def clear_local_cache(self, upc: str) -> bool:
+        """
+        Clear local cache for a specific UPC.
+        
+        Args:
+            upc: The UPC to clear
+            
+        Returns:
+            True if cache was cleared, False if it didn't exist
+        """
+        cache_file = self.cache_dir / f"{upc}.json"
+        
+        if cache_file.exists():
+            try:
+                cache_file.unlink()
+                logger.info(f"✓ Cleared local cache for UPC: {upc}")
+                return True
+            except Exception as e:
+                logger.error(f"✗ Failed to clear local cache for UPC {upc}: {e}")
+                return False
+        else:
+            logger.info(f"  No local cache found for UPC: {upc}")
+            return False
+    
+    async def clear_firestore_cache(self, upc: str) -> bool:
+        """
+        Clear Firestore cache for a specific UPC.
+        
+        Args:
+            upc: The UPC to clear
+            
+        Returns:
+            True if cache was cleared, False if it didn't exist
+        """
+        try:
+            doc_ref = self.db.collection(self.collection).document(upc)
+            doc = doc_ref.get()
+            
+            if doc.exists:
+                doc_ref.delete()
+                logger.info(f"✓ Cleared Firestore cache for UPC: {upc}")
+                return True
+            else:
+                logger.info(f"  No Firestore cache found for UPC: {upc}")
+                return False
+                
+        except Exception as e:
+            logger.error(f"✗ Failed to clear Firestore cache for UPC {upc}: {e}")
+            return False
+    
+    async def clear_cache_for_upcs(self, upcs: list[str]) -> dict:
+        """
+        Clear cache for multiple UPCs.
+        
+        Args:
+            upcs: List of UPCs to clear
+            
+        Returns:
+            Summary of cleared caches
+        """
+        logger.info(f"\n{'='*60}")
+        logger.info(f"CLEARING CACHE FOR {len(upcs)} UPCs")
+        logger.info(f"{'='*60}\n")
+        
+        cleared = 0
+        not_found = 0
+        failed = 0
+        
+        for upc in upcs:
+            if self.is_dev:
+                result = self.clear_local_cache(upc)
+            else:
+                result = await self.clear_firestore_cache(upc)
+            
+            if result:
+                cleared += 1
+            elif result is False:
+                not_found += 1
+            else:
+                failed += 1
+        
+        logger.info(f"\n{'='*60}")
+        logger.info(f"CACHE CLEARING COMPLETE")
+        logger.info(f"{'='*60}")
+        logger.info(f"Total UPCs: {len(upcs)}")
+        logger.info(f"Cleared: {cleared}")
+        logger.info(f"Not found: {not_found}")
+        logger.info(f"Failed: {failed}")
+        
+        return {
+            "total": len(upcs),
+            "cleared": cleared,
+            "not_found": not_found,
+            "failed": failed
+        }
+    
+    async def clear_cache_from_gcs_file(self, bucket_name: str, file_name: str) -> dict:
+        """
+        Clear cache for all UPCs in a GCS file.
+        
+        Args:
+            bucket_name: GCS bucket name
+            file_name: File name in the bucket
+            
+        Returns:
+            Summary of cleared caches
+        """
+        logger.info(f"Loading UPCs from gs://{bucket_name}/{file_name}")
+        
+        try:
+            client = storage.Client()
+            bucket = client.bucket(bucket_name)
+            blob = bucket.blob(file_name)
+            content = blob.download_as_text()
+            
+            # Parse UPCs
+            upcs = [line.strip() for line in content.splitlines() if line.strip()]
+            logger.info(f"Found {len(upcs)} UPCs in file")
+            
+            return await self.clear_cache_for_upcs(upcs)
+            
+        except Exception as e:
+            logger.error(f"Failed to load UPCs from GCS: {e}")
+            return {"error": str(e)}
+    
+    def list_cached_upcs(self) -> list[str]:
+        """
+        List all UPCs that have cache entries.
+        
+        Returns:
+            List of cached UPCs
+        """
+        cached_upcs = []
+        
+        if self.is_dev:
+            # List local cache files
+            if self.cache_dir.exists():
+                for cache_file in self.cache_dir.glob("*.json"):
+                    upc = cache_file.stem
+                    if upc.isdigit():  # Filter out non-UPC files
+                        cached_upcs.append(upc)
+        else:
+            # List Firestore documents
+            try:
+                docs = self.db.collection(self.collection).stream()
+                for doc in docs:
+                    cached_upcs.append(doc.id)
+            except Exception as e:
+                logger.error(f"Failed to list Firestore cache: {e}")
+        
+        return sorted(cached_upcs)
+
+
+async def main():
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Clear cache entries for specific UPCs"
+    )
+    parser.add_argument(
+        "--upcs",
+        nargs="+",
+        help="List of UPCs to clear cache for"
+    )
+    parser.add_argument(
+        "--file",
+        help="Local file containing UPCs (one per line)"
+    )
+    parser.add_argument(
+        "--gcs",
+        help="GCS path to file containing UPCs (e.g., draft-maker-bucket/usedupc7.txt)"
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="List all cached UPCs"
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Clear ALL cached entries (use with caution!)"
+    )
+    
+    args = parser.parse_args()
+    
+    cleaner = CacheCleaner()
+    
+    if args.list:
+        # List cached UPCs
+        cached_upcs = cleaner.list_cached_upcs()
+        logger.info(f"\nFound {len(cached_upcs)} cached UPCs:")
+        for upc in cached_upcs:
+            print(f"  {upc}")
+    
+    elif args.all:
+        # Clear all cache
+        response = input("Are you sure you want to clear ALL cache entries? (yes/no): ")
+        if response.lower() == "yes":
+            cached_upcs = cleaner.list_cached_upcs()
+            if cached_upcs:
+                await cleaner.clear_cache_for_upcs(cached_upcs)
+            else:
+                logger.info("No cached entries found")
+        else:
+            logger.info("Cancelled")
+    
+    elif args.upcs:
+        # Clear specific UPCs
+        await cleaner.clear_cache_for_upcs(args.upcs)
+    
+    elif args.file:
+        # Clear UPCs from local file
+        with open(args.file, "r") as f:
+            upcs = [line.strip() for line in f if line.strip()]
+        await cleaner.clear_cache_for_upcs(upcs)
+    
+    elif args.gcs:
+        # Clear UPCs from GCS file
+        parts = args.gcs.split("/", 1)
+        if len(parts) != 2:
+            logger.error("Invalid GCS path format. Use: bucket_name/file_name")
+            sys.exit(1)
+        
+        bucket_name, file_name = parts
+        await cleaner.clear_cache_from_gcs_file(bucket_name, file_name)
+    
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/components/metadata_fetcher.py
+++ b/src/components/metadata_fetcher.py
@@ -58,9 +58,15 @@ class MetadataFetcher:
         # Combine metadata
         metadata = self._combine_metadata(musicbrainz_data, discogs_data, upc)
 
-        # Cache the MBID if found
-        if metadata.get("mbid"):
-            await self.cache_manager.set_mbid(upc, metadata["mbid"], metadata)
+        # Cache the metadata if it's complete (has title, artist, and UPC)
+        # This ensures we cache Discogs-only metadata too, not just MusicBrainz
+        if metadata.get("is_complete"):
+            # Use MBID if available, otherwise use None (for Discogs-only metadata)
+            mbid = metadata.get("mbid", None)
+            await self.cache_manager.set_mbid(upc, mbid, metadata)
+            logger.debug(f"Cached metadata for UPC {upc} (MBID: {mbid or 'None - Discogs only'})")
+        else:
+            logger.debug(f"Not caching incomplete metadata for UPC {upc}")
 
         return metadata
 

--- a/src/utils/cache_manager.py
+++ b/src/utils/cache_manager.py
@@ -77,18 +77,18 @@ class CacheManager:
         return None
 
     async def set_mbid(
-        self, upc: str, mbid: str, metadata: Optional[Dict[str, Any]] = None
+        self, upc: str, mbid: Optional[str], metadata: Optional[Dict[str, Any]] = None
     ):
         """
-        Cache MBID for a UPC.
+        Cache MBID and/or metadata for a UPC.
 
         Args:
             upc: The UPC code
-            mbid: The MusicBrainz ID
+            mbid: The MusicBrainz ID (can be None for Discogs-only metadata)
             metadata: Optional additional metadata to cache
         """
         cache_data = {
-            "mbid": mbid,
+            "mbid": mbid,  # Can be None for Discogs-only metadata
             "upc": upc,
             "cached_at": datetime.now(timezone.utc),
             "expires_at": datetime.now(timezone.utc)
@@ -107,7 +107,11 @@ class CacheManager:
         else:
             await self._save_to_firestore(upc, cache_data)
 
-        logger.info(f"Cached MBID {mbid} for UPC {upc}")
+        # Log appropriately based on whether we have an MBID
+        if mbid:
+            logger.info(f"Cached MBID {mbid} for UPC {upc}")
+        else:
+            logger.info(f"Cached metadata (Discogs-only, no MBID) for UPC {upc}")
 
     async def get_metadata(self, upc: str) -> Optional[Dict[str, Any]]:
         """

--- a/tests/test_discogs_metadata_bug.py
+++ b/tests/test_discogs_metadata_bug.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+Test to identify and debug the issue where Discogs metadata is being disregarded
+when MusicBrainz API returns no results, causing draft creation to fail.
+
+This test focuses on UPCs from draft-maker-bucket/usedupc7.txt that fail to
+return data from MusicBrainz but should successfully retrieve metadata from Discogs.
+"""
+
+import asyncio
+import sys
+import json
+from pathlib import Path
+from typing import Dict, Any, List
+from datetime import datetime
+
+# Add the parent directory to the path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.config import settings
+from src.utils.logger import get_logger, setup_logging
+from src.components.metadata_fetcher import get_metadata_fetcher
+from src.components.pricing_fetcher import get_pricing_fetcher
+from src.components.image_fetcher import get_image_fetcher
+from src.components.draft_composer import get_draft_composer
+from src.orchestrator import ListingOrchestrator
+from google.cloud import storage
+
+# Enable DEBUG level logging to see all details
+setup_logging("DEBUG")
+logger = get_logger(__name__)
+
+
+class DiscogsMetadataBugTester:
+    """Test harness for debugging the Discogs metadata bug."""
+    
+    def __init__(self):
+        """Initialize test components."""
+        self.metadata_fetcher = get_metadata_fetcher()
+        self.pricing_fetcher = get_pricing_fetcher()
+        self.image_fetcher = get_image_fetcher()
+        self.draft_composer = get_draft_composer()
+        self.orchestrator = ListingOrchestrator()
+        self.storage_client = storage.Client()
+        
+    async def get_problematic_upcs_from_gcs(self, limit: int = 5) -> List[str]:
+        """
+        Get UPCs from usedupc7.txt that are likely to have the issue.
+        
+        Args:
+            limit: Maximum number of UPCs to return
+            
+        Returns:
+            List of UPC codes to test
+        """
+        try:
+            bucket = self.storage_client.bucket("draft-maker-bucket")
+            blob = bucket.blob("usedupc7.txt")
+            content = blob.download_as_text()
+            
+            # Parse UPCs from the file
+            upcs = [line.strip() for line in content.splitlines() if line.strip()]
+            
+            # Return limited number for testing
+            return upcs[:limit]
+            
+        except Exception as e:
+            logger.error(f"Failed to load UPCs from GCS: {e}")
+            # Fallback to known problematic UPCs
+            return [
+                "075596251129",
+                "718751853928",
+                "018663462622",
+                "727057570422",
+                "075679228529"
+            ][:limit]
+    
+    async def test_metadata_fetching_flow(self, upc: str) -> Dict[str, Any]:
+        """
+        Test metadata fetching for a single UPC to identify where data is lost.
+        
+        Args:
+            upc: UPC code to test
+            
+        Returns:
+            Detailed test results
+        """
+        logger.info(f"\n{'='*80}")
+        logger.info(f"TESTING UPC: {upc}")
+        logger.info(f"{'='*80}")
+        
+        result = {
+            "upc": upc,
+            "timestamp": datetime.utcnow().isoformat(),
+            "musicbrainz_response": None,
+            "discogs_response": None,
+            "combined_metadata": None,
+            "draft_creation": None,
+            "errors": []
+        }
+        
+        try:
+            # Step 1: Test MusicBrainz API directly
+            logger.info("\n[STEP 1] Testing MusicBrainz API...")
+            musicbrainz_data = await self.metadata_fetcher._fetch_from_musicbrainz(upc)
+            
+            if musicbrainz_data:
+                logger.info(f"✓ MusicBrainz returned data: {json.dumps(musicbrainz_data, indent=2)[:500]}...")
+                result["musicbrainz_response"] = {
+                    "found": True,
+                    "has_title": bool(musicbrainz_data.get("title")),
+                    "has_artist": bool(musicbrainz_data.get("artist_name")),
+                    "has_mbid": bool(musicbrainz_data.get("mbid")),
+                    "data": musicbrainz_data
+                }
+            else:
+                logger.warning("✗ MusicBrainz returned no data (empty dict)")
+                result["musicbrainz_response"] = {
+                    "found": False,
+                    "data": None
+                }
+            
+            # Step 2: Test Discogs API directly
+            logger.info("\n[STEP 2] Testing Discogs API...")
+            discogs_data = await self.metadata_fetcher._fetch_from_discogs(upc)
+            
+            if discogs_data:
+                logger.info(f"✓ Discogs returned data: {json.dumps(discogs_data, indent=2)[:500]}...")
+                result["discogs_response"] = {
+                    "found": True,
+                    "has_title": bool(discogs_data.get("title")),
+                    "has_artist": bool(discogs_data.get("artist_name")),
+                    "has_discogs_id": bool(discogs_data.get("discogs_id")),
+                    "data": discogs_data
+                }
+            else:
+                logger.warning("✗ Discogs returned no data")
+                result["discogs_response"] = {
+                    "found": False,
+                    "data": None
+                }
+            
+            # Step 3: Test metadata combination
+            logger.info("\n[STEP 3] Testing metadata combination...")
+            combined = self.metadata_fetcher._combine_metadata(
+                musicbrainz_data or {},
+                discogs_data or {},
+                upc
+            )
+            
+            logger.info(f"Combined metadata: {json.dumps(combined, indent=2)[:500]}...")
+            result["combined_metadata"] = {
+                "is_complete": combined.get("is_complete"),
+                "has_title": bool(combined.get("title")),
+                "has_artist": bool(combined.get("artist_name")),
+                "sources": combined.get("metadata_sources", []),
+                "data": combined
+            }
+            
+            # Step 4: Test full metadata fetch (with caching)
+            logger.info("\n[STEP 4] Testing full metadata fetch...")
+            full_metadata = await self.metadata_fetcher.fetch_metadata(upc)
+            
+            if full_metadata and full_metadata.get("is_complete"):
+                logger.info(f"✓ Full metadata fetch successful: {full_metadata.get('artist_name')} - {full_metadata.get('title')}")
+            else:
+                logger.warning(f"✗ Full metadata fetch incomplete or failed")
+                result["errors"].append("Full metadata fetch returned incomplete data")
+            
+            # Step 5: Test orchestrator processing
+            logger.info("\n[STEP 5] Testing orchestrator processing...")
+            orchestrator_result = await self.orchestrator.process_single_upc(upc, create_draft=False)
+            
+            if orchestrator_result.get("success"):
+                logger.info("✓ Orchestrator processing successful")
+            else:
+                logger.warning(f"✗ Orchestrator processing failed: {orchestrator_result.get('error')}")
+                result["errors"].append(f"Orchestrator failed: {orchestrator_result.get('error')}")
+            
+            result["orchestrator_result"] = orchestrator_result
+            
+            # Step 6: If metadata is complete, test draft creation
+            if full_metadata and full_metadata.get("is_complete"):
+                logger.info("\n[STEP 6] Testing draft creation with metadata...")
+                
+                # Get pricing
+                pricing = await self.pricing_fetcher.fetch_pricing(full_metadata)
+                if not pricing or not pricing.get("recommended_price"):
+                    pricing = {
+                        "recommended_price": 9.99,
+                        "min_price": 7.99,
+                        "max_price": 12.99,
+                        "confidence": "none",
+                        "sample_size": 0,
+                        "source": "default"
+                    }
+                
+                # Get images
+                images = await self.image_fetcher.fetch_images(full_metadata)
+                if not images:
+                    images = {"primary_image": None, "images": []}
+                
+                # Try to create draft
+                draft_result = await self.draft_composer.create_draft_listing(
+                    metadata=full_metadata,
+                    images=images,
+                    pricing=pricing
+                )
+                
+                result["draft_creation"] = draft_result
+                
+                if draft_result.get("success"):
+                    logger.info(f"✓ Draft creation successful - SKU: {draft_result.get('sku')}")
+                    if draft_result.get("listing_id"):
+                        logger.info(f"✓ Listing published - ID: {draft_result.get('listing_id')}")
+                    else:
+                        logger.warning("✗ Draft created but not published")
+                else:
+                    logger.error(f"✗ Draft creation failed: {draft_result.get('error')}")
+                    result["errors"].append(f"Draft creation failed: {draft_result.get('error')}")
+            
+        except Exception as e:
+            logger.error(f"Unexpected error during testing: {e}", exc_info=True)
+            result["errors"].append(f"Exception: {str(e)}")
+        
+        return result
+    
+    async def run_full_test(self):
+        """Run the complete test suite."""
+        logger.info("\n" + "="*80)
+        logger.info("DISCOGS METADATA BUG TEST")
+        logger.info("Testing UPCs that fail MusicBrainz but should work with Discogs")
+        logger.info("="*80)
+        
+        # Get problematic UPCs
+        upcs = await self.get_problematic_upcs_from_gcs(limit=3)
+        logger.info(f"\nTesting {len(upcs)} UPCs from usedupc7.txt")
+        
+        results = []
+        for upc in upcs:
+            result = await self.test_metadata_fetching_flow(upc)
+            results.append(result)
+            
+            # Add delay between tests
+            await asyncio.sleep(2)
+        
+        # Analyze results
+        logger.info("\n" + "="*80)
+        logger.info("TEST RESULTS SUMMARY")
+        logger.info("="*80)
+        
+        successful = 0
+        musicbrainz_only = 0
+        discogs_only = 0
+        both_sources = 0
+        failed = 0
+        
+        for result in results:
+            upc = result["upc"]
+            mb_found = result["musicbrainz_response"]["found"] if result["musicbrainz_response"] else False
+            discogs_found = result["discogs_response"]["found"] if result["discogs_response"] else False
+            combined_complete = result["combined_metadata"]["is_complete"] if result["combined_metadata"] else False
+            
+            if mb_found and discogs_found:
+                both_sources += 1
+            elif mb_found:
+                musicbrainz_only += 1
+            elif discogs_found:
+                discogs_only += 1
+            
+            if combined_complete:
+                successful += 1
+                status = "✓ SUCCESS"
+            else:
+                failed += 1
+                status = "✗ FAILED"
+            
+            logger.info(f"\n{status} - UPC: {upc}")
+            logger.info(f"  MusicBrainz: {'Found' if mb_found else 'Not found'}")
+            logger.info(f"  Discogs: {'Found' if discogs_found else 'Not found'}")
+            logger.info(f"  Combined metadata complete: {combined_complete}")
+            
+            if result["errors"]:
+                logger.info(f"  Errors: {', '.join(result['errors'])}")
+            
+            if result.get("draft_creation"):
+                draft = result["draft_creation"]
+                if draft.get("success"):
+                    logger.info(f"  Draft: Created (SKU: {draft.get('sku')})")
+                    if draft.get("listing_id"):
+                        logger.info(f"  Listing: Published (ID: {draft.get('listing_id')})")
+                else:
+                    logger.info(f"  Draft: Failed - {draft.get('error')}")
+        
+        logger.info("\n" + "-"*40)
+        logger.info(f"Total tested: {len(results)}")
+        logger.info(f"Successful: {successful}")
+        logger.info(f"Failed: {failed}")
+        logger.info(f"Data sources:")
+        logger.info(f"  - Both APIs: {both_sources}")
+        logger.info(f"  - MusicBrainz only: {musicbrainz_only}")
+        logger.info(f"  - Discogs only: {discogs_only}")
+        
+        # Save detailed results
+        output_file = Path("tests/test_results/discogs_bug_test_results.json")
+        output_file.parent.mkdir(exist_ok=True)
+        
+        with open(output_file, "w") as f:
+            json.dump({
+                "test_run": datetime.utcnow().isoformat(),
+                "summary": {
+                    "total": len(results),
+                    "successful": successful,
+                    "failed": failed,
+                    "both_sources": both_sources,
+                    "musicbrainz_only": musicbrainz_only,
+                    "discogs_only": discogs_only
+                },
+                "detailed_results": results
+            }, f, indent=2, default=str)
+        
+        logger.info(f"\nDetailed results saved to: {output_file}")
+        
+        return results
+
+
+async def main():
+    """Main entry point."""
+    tester = DiscogsMetadataBugTester()
+    results = await tester.run_full_test()
+    
+    # Check if any tests failed
+    failed_tests = [r for r in results if r.get("errors")]
+    if failed_tests:
+        logger.error(f"\n⚠️  {len(failed_tests)} tests encountered errors")
+        sys.exit(1)
+    else:
+        logger.info(f"\n✓ All tests completed successfully")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
This PR fixes a critical caching issue where metadata from Discogs was not being cached when no MusicBrainz data was available, causing repeated API calls and potential rate limiting issues.

## Problem
- When a UPC only had Discogs data (no MusicBrainz), the metadata was NOT being cached
- This caused repeated API calls for the same UPC every time it was processed
- Led to performance issues and potential rate limiting

## Solution
- Modified `metadata_fetcher.py` to cache ALL complete metadata, not just when MBID exists
- Updated `cache_manager.py` to properly handle None MBID values for Discogs-only metadata
- Added utility script to clear stale cache entries when needed

## Changes
- 🐛 **Fix**: Cache all complete metadata regardless of source
- ✨ **Feature**: Added `clear_cache_for_upcs.py` utility script
- ✅ **Test**: Added comprehensive test for Discogs metadata bug
- 📝 **Docs**: Added debug logging for cache operations

## Testing
- Tested with UPC 718751853928 which only has Discogs data
- Verified metadata is now properly cached on first fetch
- Confirmed subsequent fetches use cache instead of hitting APIs
- All existing tests pass

## Impact
- ⚡ Better performance - reduced API calls
- 🛡️ Reduced rate limiting issues
- 💾 Proper caching for all metadata sources

## Deployment
This PR will trigger automatic deployment to production via GitHub Actions.